### PR TITLE
Changing bfd_section_size arguments

### DIFF
--- a/opencog/util/backtrace-symbols.c
+++ b/opencog/util/backtrace-symbols.c
@@ -127,9 +127,9 @@ static void find_address_in_section(bfd *abfd, asection *section, void *data)
     size = bfd_section_size(section);
     if (spot->pc >= vma + size) return;
 #else
-    if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0) return;
+    if ((bfd_section_flags(section) & SEC_ALLOC) == 0) return;
 
-    vma = bfd_get_section_vma(abfd, section);
+    vma = bfd_section_vma(section);
     if (spot->pc < vma) return;
 
     size = bfd_section_size(section);

--- a/opencog/util/backtrace-symbols.c
+++ b/opencog/util/backtrace-symbols.c
@@ -132,7 +132,7 @@ static void find_address_in_section(bfd *abfd, asection *section, void *data)
     vma = bfd_get_section_vma(abfd, section);
     if (spot->pc < vma) return;
 
-    size = bfd_section_size(abfd, section);
+    size = bfd_section_size(section);
     if (spot->pc >= vma + size) return;
 #endif
     spot->found = bfd_find_nearest_line(abfd, section, spot->syms, spot->pc - vma,


### PR DESCRIPTION
I was trying to compile cogutil from source and got a compile error, thinking maybe a few bfd.h functions were called with the wrong signatures.
I'm not 100% sure though, I don't actually understand what this code does or why, but this change seemed to fix the compile and naively looks to me to be what was intended.